### PR TITLE
Extend documentation for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,220 @@
+# Project-specific files
+*.npy
+*.png
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/2-planes-flow-mesh.py
+++ b/2-planes-flow-mesh.py
@@ -6,27 +6,32 @@
 
 # this first part just does the GPU intensive stuff
 
-# usage: ./2-planes-flow-mesh.py <data-loader> <patch-size> <stride> <batch-size>
-
 import os
-import sys
+import argparse
 import time
-
-import jax
-import jax.numpy as jnp
-import numpy as np
-
-from sofima import flow_field
-from sofima import flow_utils
-from sofima import map_utils
-from sofima import mesh
-
 import importlib
 
-data_loader, patch_size, stride, batch_size = sys.argv[1:]
-patch_size = int(patch_size)
-stride = int(stride)
-batch_size = int(batch_size)
+import numpy as np
+from sofima import flow_field
+from sofima import flow_utils
+from sofima import mesh
+
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(
+    description="Takes a pair of slices and aligns them - GPU intensive processing"
+)
+parser.add_argument('data_loader', help='Data loader module name')
+parser.add_argument('patch_size', type=int, help='Patch size for processing')
+parser.add_argument('stride', type=int, help='Stride value for processing')
+parser.add_argument('batch_size', type=int, help='Batch size for processing')
+
+args = parser.parse_args()
+
+data_loader = args.data_loader
+patch_size = args.patch_size
+stride = args.stride
+batch_size = args.batch_size
 
 print("data_loader =", data_loader)
 print("patch_size =", patch_size)
@@ -72,7 +77,7 @@ print("clean_flow took", time.time() - t0, "sec")
 # find a configuration of the imagery that is compatible with the estimated
 # flow field and preserves the original geometry as much as possible.
 config = mesh.IntegrationConfig(dt=0.001, gamma=0.0, k0=0.01, k=0.1, stride=(stride, stride),
-                                num_iters=1000, max_iters=100000, 
+                                num_iters=1000, max_iters=100000,
                                 stop_v_max=0.005, dt_max=1000, start_cap=0.01,
                                 final_cap=10, prefer_orig_order=True)
 

--- a/2-planes-flow-mesh.py
+++ b/2-planes-flow-mesh.py
@@ -21,10 +21,25 @@ from sofima import mesh
 parser = argparse.ArgumentParser(
     description="Takes a pair of slices and aligns them - GPU intensive processing"
 )
-parser.add_argument('data_loader', help='Data loader module name')
-parser.add_argument('patch_size', type=int, help='Patch size for processing')
-parser.add_argument('stride', type=int, help='Stride value for processing')
-parser.add_argument('batch_size', type=int, help='Batch size for processing')
+parser.add_argument(
+    "data_loader",
+    help="Data loader module name, e.g., data-test-2-planes"
+)
+parser.add_argument(
+    "patch_size",
+    type=int,
+    help="Side length of (square) patch for processing (in pixels, e.g., 32)",
+)
+parser.add_argument(
+    "stride",
+    type=int,
+    help="Distance of adjacent patches (in pixels, e.g., 8)"
+)
+parser.add_argument(
+    "batch_size",
+    type=int,
+    help="Batch size for processing"
+)
 
 args = parser.parse_args()
 

--- a/2-planes-invmap.py
+++ b/2-planes-invmap.py
@@ -18,9 +18,20 @@ from sofima import map_utils
 parser = argparse.ArgumentParser(
     description="CPU-intensive inverse mapping - depends on output of 2-planes-flow-mesh.py"
 )
-parser.add_argument('data_loader', help='Data loader module name')
-parser.add_argument('patch_size', type=int, help='Patch size for processing')
-parser.add_argument('stride', type=int, help='Stride value for processing')
+parser.add_argument(
+    "data_loader",
+    help="Data loader module name, e.g., data-test-2-planes"
+)
+parser.add_argument(
+    "patch_size",
+    type=int,
+    help="Side length of (square) patch for processing (in pixels, e.g., 32)",
+)
+parser.add_argument(
+    "stride",
+    type=int,
+    help="Distance of adjacent patches (in pixels, e.g., 8)"
+)
 
 args = parser.parse_args()
 

--- a/2-planes-invmap.py
+++ b/2-planes-invmap.py
@@ -5,22 +5,28 @@
 # this second part only uses the CPU (and also a lot of RAM).  it depends on the
 # output of 2-planes-flow-mesh.py
 
-# usage : ./2-planes-invmap.py <data-loader> <patch-size> <stride>
-
 import os
-import sys
+import argparse
 import time
-
-import jax
+import importlib
 
 from connectomics.common import bounding_box
 from sofima import map_utils
 
-import importlib
 
-data_loader, patch_size, stride = sys.argv[1:]
-patch_size = int(patch_size)
-stride = int(stride)
+# Parse command line arguments
+parser = argparse.ArgumentParser(
+    description="CPU-intensive inverse mapping - depends on output of 2-planes-flow-mesh.py"
+)
+parser.add_argument('data_loader', help='Data loader module name')
+parser.add_argument('patch_size', type=int, help='Patch size for processing')
+parser.add_argument('stride', type=int, help='Stride value for processing')
+
+args = parser.parse_args()
+
+data_loader = args.data_loader
+patch_size = args.patch_size
+stride = args.stride
 
 print("data_loader =", data_loader)
 print("patch_size =", patch_size)

--- a/2-planes-test.py
+++ b/2-planes-test.py
@@ -2,21 +2,29 @@
 
 # a derivative of https://github.com/google-research/sofima/blob/main/notebooks/em_alignment.ipynb
 
-# generate overlapped images to test that everything works
-
-# usage: ./2-planes-test.py <data-loader> <patch-size> <stride>
-
 import os
+import argparse
+import importlib
+
 import numpy as np
 from connectomics.common import bounding_box
 from sofima import warp
 import matplotlib.pyplot as plt
 
-import importlib
 
-data_loader, patch_size, stride = sys.argv[1:]
-patch_size = int(patch_size)
-stride = int(stride)
+# Parse command line arguments
+parser = argparse.ArgumentParser(
+    description="Generate overlapped images to test that everything works"
+)
+parser.add_argument('data_loader', help='Data loader module name')
+parser.add_argument('patch_size', type=int, help='Patch size for processing')
+parser.add_argument('stride', type=int, help='Stride value for processing')
+
+args = parser.parse_args()
+
+data_loader = args.data_loader
+patch_size = args.patch_size
+stride = args.stride
 
 print("data_loader =", data_loader)
 print("patch_size =", patch_size)
@@ -78,7 +86,7 @@ warp_ovr[:,:,2] = qscale(warped[1])
 def set_axis(ax, t):
     ax.set_title(t)
     ax.set_xlabel('x'); ax.set_ylabel('y')
-    ax.set_xticklabels([]);  ax.set_yticklabels([]);
+    ax.set_xticklabels([]);  ax.set_yticklabels([])
     ax.set_xticks([]);  ax.set_yticks([]);
 
 fig, axs = plt.subplots(2, 3, figsize=(6, 8))

--- a/2-planes-test.py
+++ b/2-planes-test.py
@@ -16,9 +16,20 @@ import matplotlib.pyplot as plt
 parser = argparse.ArgumentParser(
     description="Generate overlapped images to test that everything works"
 )
-parser.add_argument('data_loader', help='Data loader module name')
-parser.add_argument('patch_size', type=int, help='Patch size for processing')
-parser.add_argument('stride', type=int, help='Stride value for processing')
+parser.add_argument(
+    "data_loader",
+    help="Data loader module name, e.g., data-test-2-planes"
+)
+parser.add_argument(
+    "patch_size",
+    type=int,
+    help="Side length of (square) patch for processing (in pixels, e.g., 32)",
+)
+parser.add_argument(
+    "stride",
+    type=int,
+    help="Distance of adjacent patches (in pixels, e.g., 8)"
+)
 
 args = parser.parse_args()
 

--- a/2-volumes-flow-mesh.py
+++ b/2-volumes-flow-mesh.py
@@ -22,10 +22,25 @@ from sofima.mesh import elastic_mesh_3d
 parser = argparse.ArgumentParser(
     description="Takes a pair of overlapping volumes and aligns them - GPU intensive processing"
 )
-parser.add_argument('data_loader', help='Data loader module name')
-parser.add_argument('patch_size', type=int, help='Patch size for processing')
-parser.add_argument('stride', type=int, help='Stride value for processing')
-parser.add_argument('batch_size', type=int, help='Batch size for processing')
+parser.add_argument(
+    "data_loader",
+    help="Data loader module name, e.g., data-test-2-planes"
+)
+parser.add_argument(
+    "patch_size",
+    type=int,
+    help="Side length of (square) patch for processing (in pixels, e.g., 32)",
+)
+parser.add_argument(
+    "stride",
+    type=int,
+    help="Distance of adjacent patches (in pixels, e.g., 8)"
+)
+parser.add_argument(
+    'batch_size',
+    type=int,
+    help='Batch size for processing'
+)
 
 args = parser.parse_args()
 

--- a/2-volumes-flow-mesh.py
+++ b/2-volumes-flow-mesh.py
@@ -6,28 +6,33 @@
 
 # this first part just does the GPU intensive stuff
 
-# usage: ./2-volumes-flow-mesh.py <patch-size> <stride> <batch-size>
-
 import os
-import sys
+import argparse
 import time
+import importlib
 
-import jax
-import jax.numpy as jnp
 import numpy as np
-
 from sofima import flow_field
 from sofima import flow_utils
-from sofima import map_utils
 from sofima import mesh
 from sofima.mesh import elastic_mesh_3d
 
-import importlib
 
-data_loader, patch_size, stride, batch_size = sys.argv[1:]
-patch_size = int(patch_size)
-stride = int(stride)
-batch_size = int(batch_size)
+# Parse command line arguments
+parser = argparse.ArgumentParser(
+    description="Takes a pair of overlapping volumes and aligns them - GPU intensive processing"
+)
+parser.add_argument('data_loader', help='Data loader module name')
+parser.add_argument('patch_size', type=int, help='Patch size for processing')
+parser.add_argument('stride', type=int, help='Stride value for processing')
+parser.add_argument('batch_size', type=int, help='Batch size for processing')
+
+args = parser.parse_args()
+
+data_loader = args.data_loader
+patch_size = args.patch_size
+stride = args.stride
+batch_size = args.batch_size
 
 print("data_loader =", data_loader)
 print("patch_size =", patch_size)

--- a/2-volumes-invmap.py
+++ b/2-volumes-invmap.py
@@ -5,22 +5,28 @@
 # this second part only uses the CPU (and also a lot of RAM).  it depends on the
 # output of 2-volumes-flow-mesh.py
 
-# usage : ./2-volumes-invmap.py <patch-size> <stride>
-
 import os
-import sys
+import argparse
 import time
-
-import jax
+import importlib
 
 from connectomics.common import bounding_box
 from sofima import map_utils
 
-import importlib
 
-data_loader, patch_size, stride = sys.argv[1:]
-patch_size = int(patch_size)
-stride = int(stride)
+# Parse command line arguments
+parser = argparse.ArgumentParser(
+    description="CPU-intensive inverse mapping - depends on output of 2-volumes-flow-mesh.py"
+)
+parser.add_argument('data_loader', help='Data loader module name')
+parser.add_argument('patch_size', type=int, help='Patch size for processing')
+parser.add_argument('stride', type=int, help='Stride value for processing')
+
+args = parser.parse_args()
+
+data_loader = args.data_loader
+patch_size = args.patch_size
+stride = args.stride
 
 print("data_loader =", data_loader)
 print("patch_size =", patch_size)

--- a/2-volumes-invmap.py
+++ b/2-volumes-invmap.py
@@ -18,9 +18,20 @@ from sofima import map_utils
 parser = argparse.ArgumentParser(
     description="CPU-intensive inverse mapping - depends on output of 2-volumes-flow-mesh.py"
 )
-parser.add_argument('data_loader', help='Data loader module name')
-parser.add_argument('patch_size', type=int, help='Patch size for processing')
-parser.add_argument('stride', type=int, help='Stride value for processing')
+parser.add_argument(
+    "data_loader",
+    help="Data loader module name, e.g., data-test-2-planes"
+)
+parser.add_argument(
+    "patch_size",
+    type=int,
+    help="Side length of (square) patch for processing (in pixels, e.g., 32)",
+)
+parser.add_argument(
+    "stride",
+    type=int,
+    help="Distance of adjacent patches (in pixels, e.g., 8)"
+)
 
 args = parser.parse_args()
 

--- a/2-volumes-test.py
+++ b/2-volumes-test.py
@@ -2,21 +2,29 @@
 
 # a derivative of https://github.com/google-research/sofima/blob/main/notebooks/em_alignment.ipynb
 
-# generate overlapped images to test that everything works
-
-# usage: ./2-volumes-test.py <data-loader> <patch-size> <stride>
-
 import os
+import argparse
+import importlib
+
 import numpy as np
 from connectomics.common import bounding_box
 from sofima import warp
 import matplotlib.pyplot as plt
 
-import importlib
 
-data_loader, patch_size, stride = sys.argv[1:]
-patch_size = int(patch_size)
-stride = int(stride)
+# Parse command line arguments
+parser = argparse.ArgumentParser(
+    description="Generate overlapped images to test that everything works"
+)
+parser.add_argument('data_loader', help='Data loader module name')
+parser.add_argument('patch_size', type=int, help='Patch size for processing')
+parser.add_argument('stride', type=int, help='Stride value for processing')
+
+args = parser.parse_args()
+
+data_loader = args.data_loader
+patch_size = args.patch_size
+stride = args.stride
 
 print("data_loader =", data_loader)
 print("patch_size =", patch_size)
@@ -81,7 +89,7 @@ warp_ovr[:,:,2] = qscale(warped[1][:,:,iz])
 def set_axis(ax, t):
     ax.set_title(t)
     ax.set_xlabel('x'); ax.set_ylabel('y')
-    ax.set_xticklabels([]);  ax.set_yticklabels([]);
+    ax.set_xticklabels([]);  ax.set_yticklabels([])
     ax.set_xticks([]);  ax.set_yticks([]);
 
 fig, axs = plt.subplots(2, 3, figsize=(6, 8))
@@ -136,8 +144,8 @@ warp_ovr[:,:,2] = qscale(warped[1][:,iy,:])
 def set_axis(ax, t):
     ax.set_title(t)
     ax.set_xlabel('x'); ax.set_ylabel('z')
-    ax.set_xticklabels([]);  ax.set_yticklabels([]);
-    ax.set_xticks([]);  ax.set_yticks([]);
+    ax.set_xticklabels([]);  ax.set_yticklabels([])
+    ax.set_xticks([]);  ax.set_yticks([])
 
 fig, axs = plt.subplots(2, 3, figsize=(6, 8))
 axs[0,0].imshow(orig_top, vmin=0, vmax=1)

--- a/2-volumes-test.py
+++ b/2-volumes-test.py
@@ -16,9 +16,20 @@ import matplotlib.pyplot as plt
 parser = argparse.ArgumentParser(
     description="Generate overlapped images to test that everything works"
 )
-parser.add_argument('data_loader', help='Data loader module name')
-parser.add_argument('patch_size', type=int, help='Patch size for processing')
-parser.add_argument('stride', type=int, help='Stride value for processing')
+parser.add_argument(
+    "data_loader",
+    help="Data loader module name, e.g., data-test-2-planes"
+)
+parser.add_argument(
+    "patch_size",
+    type=int,
+    help="Side length of (square) patch for processing (in pixels, e.g., 32)",
+)
+parser.add_argument(
+    "stride",
+    type=int,
+    help="Distance of adjacent patches (in pixels, e.g., 8)"
+)
 
 args = parser.parse_args()
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,28 @@ flow fields are only calculated at a single resolution
 
 # development
 
-unit tests are in 2-{planes,volumes}-test.py and use
-data-test-2-{planes,volumes}.py.  for 2-planes-test.py the following figure
-should be generated:
+Unit tests are in 2-{planes,volumes}-test.py and use data-test-2-{planes,volumes}.py.
+
+### Aligning two planes
+
+Run
+```bash
+python 2-planes-flow-mesh.py data-test-2-planes 16 8 1
+python 2-planes-invmap.py data-test-2-planes 16 8
+python 2-planes-test.py data-test-2-planes 16 8
+```
+  
+The following figure should be generated (overlay.png):
 
 ![output of unit tests](overlay.png)
+
+### Aligning a full volume
+
+Run
+```bash
+python 2-volumes-flow-mesh.py data-test-2-volumes 32 8 2
+python 2-volumes-invmap.py data-test-2-volumes 32 8
+python 2-volumes-test.py data-test-2-volumes 32 8
+```
+
+There should be two figures generated (overlay-xy.png and overlay-xz.png) that show the alignment in XY and XZ planes, respectively.

--- a/data-test-2-planes.py
+++ b/data-test-2-planes.py
@@ -4,7 +4,6 @@
 # 2-planes-invmap.py data-test-2-planes 16 8
 # 2-planes-test.py data-test-2-planes 16 8
 
-import os
 import numpy as np
 
 shift=8

--- a/data-test-2-volumes.py
+++ b/data-test-2-volumes.py
@@ -4,7 +4,6 @@
 # 2-volumes-invmap.py data-test-2-volumes 32 8
 # 2-volumes-test.py data-test-2-volumes 32 8
 
-import os
 import numpy as np
 
 shift=4


### PR DESCRIPTION
While running the pipeline with the provided test data, I aggregated all information that I needed to run it in the README. Also, I ported argument handling to `argparse` to make error messages more expressive.